### PR TITLE
chore: swap CODEOWNERS over to the `swf` team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
-* @UncleGedd @jeff-mccoy @decleaver @mjnagel
+# This repository is owned by the Software Factory Team
+/* @defenseunicorns/swf
+
+# Additional privileged files
+/CODEOWNERS @jeff-mccoy @austenbryan
+/LICENSE @jeff-mccoy @austenbryan


### PR DESCRIPTION
## Description

This PR updates the CODEOWNERS to the `swf` team

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
