### PR TITLE
chore: allow vendor overrides for env var variables

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -59,10 +59,12 @@ var runCmd = &cobra.Command{
 		// ensure vars are uppercase
 		setRunnerVariables = helpers.TransformMapKeys(setRunnerVariables, strings.ToUpper)
 
-		// set any env vars that come from the environment
+		// set any env vars that come from the environment (taking MARU_ over VENDOR_)
 		for _, variable := range tasksFile.Variables {
 			if _, ok := setRunnerVariables[variable.Name]; !ok {
 				if value := os.Getenv(fmt.Sprintf("%s_%s", strings.ToUpper(config.EnvPrefix), variable.Name)); value != "" {
+					setRunnerVariables[variable.Name] = value
+				} else if value := os.Getenv(fmt.Sprintf("%s_%s", strings.ToUpper(config.VendorPrefix), variable.Name)); value != "" {
 					setRunnerVariables[variable.Name] = value
 				}
 			}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -64,8 +64,10 @@ var runCmd = &cobra.Command{
 			if _, ok := setRunnerVariables[variable.Name]; !ok {
 				if value := os.Getenv(fmt.Sprintf("%s_%s", strings.ToUpper(config.EnvPrefix), variable.Name)); value != "" {
 					setRunnerVariables[variable.Name] = value
-				} else if value := os.Getenv(fmt.Sprintf("%s_%s", strings.ToUpper(config.VendorPrefix), variable.Name)); value != "" {
-					setRunnerVariables[variable.Name] = value
+				} else if config.VendorPrefix != "" {
+					if value := os.Getenv(fmt.Sprintf("%s_%s", strings.ToUpper(config.VendorPrefix), variable.Name)); value != "" {
+						setRunnerVariables[variable.Name] = value
+					}
 				}
 			}
 		}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -33,6 +33,9 @@ var (
 	// TempDirectory is the directory to store temporary files
 	TempDirectory string
 
+	// VendorPrefix is the prefix for environment variables that an application vendoring Maru wants to use
+	VendorPrefix string
+
 	extraEnv = map[string]string{"MARU": "true", "MARU_ARCH": GetArch()}
 )
 


### PR DESCRIPTION
## Description

This allows env vars to be pulled in from a vendored prefix as well as MARU_

## Related Issue

Fixes #N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
