### PR TITLE
chore: improve spinner when used with `--no-progress`

### DIFF
--- a/src/message/spinner.go
+++ b/src/message/spinner.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/defenseunicorns/pkg/helpers/v2"
@@ -56,7 +57,7 @@ var NewProgressSpinner = func(format string, a ...any) helpers.ProgressWriter {
 func (p *Spinner) Write(raw []byte) (int, error) {
 	size := len(raw)
 	if NoProgress {
-		pterm.Printfln("     %s", string(raw))
+		os.Stderr.Write(raw)
 
 		return size, nil
 	}
@@ -66,7 +67,8 @@ func (p *Spinner) Write(raw []byte) (int, error) {
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
 		text := pterm.Sprintf("     %s", scanner.Text())
-		pterm.Fprinto(p.spinner.Writer, strings.Repeat(" ", pterm.GetTerminalWidth()))
+		// Clear the current line with the ANSI escape code
+		pterm.Fprinto(p.spinner.Writer, "\033[K")
 		pterm.Fprintln(p.spinner.Writer, text)
 	}
 

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -137,6 +137,14 @@ func TestTaskRunner(t *testing.T) {
 		require.Contains(t, stdErr, "task loop detected")
 	})
 
+	t.Run("run interactive (with --no-progress)", func(t *testing.T) {
+		t.Parallel()
+		stdOut, stdErr, err := e2e.Maru("run", "interactive", "--file", "src/test/tasks/tasks.yaml", "--no-progress")
+		require.NoError(t, err, stdOut, stdErr)
+		// Ensure there are no extra chars that will interrupt interactive programs (i.e. a spinner) when --no-progress is set
+		require.Contains(t, stdErr, "\033[G ⬒ Spinning...\033[G ⬔ Spinning...\033[G ◨ Spinning...")
+	})
+
 	t.Run("test includes paths", func(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "foobar", "--file", "src/test/tasks/tasks.yaml")

--- a/src/test/tasks/tasks.yaml
+++ b/src/test/tasks/tasks.yaml
@@ -31,6 +31,26 @@ tasks:
   - name: action
     actions:
       - cmd: echo "specific test string"
+  - name: interactive
+    description: Run an interactive task
+    actions:
+      - description: Create a spinner that spins
+        cmd: |
+          printf '\033[G ⬒ Spinning...'
+          sleep 0.1
+          printf '\033[G ⬔ Spinning...'
+          sleep 0.1
+          printf '\033[G ◨ Spinning...'
+          sleep 0.1
+          printf '\033[G ◪ Spinning...'
+          sleep 0.1
+          printf '\033[G ⬓ Spinning...'
+          sleep 0.1
+          printf '\033[G ⬕ Spinning...'
+          sleep 0.1
+          printf '\033[G ◧ Spinning...'
+          sleep 0.1
+          printf '\033[G ◩ Spinning...'
   - name: cmd-set-variable
     actions:
       - cmd: echo unique-value


### PR DESCRIPTION
## Description

This slightly improves the spinner to allow for interactive programs to run when `--no-progress` is provided.

## Related Issue

Relates to #103

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
