### PR TITLE
chore: fix goreleaser args

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --debug
+          args: release --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --verbose
+          args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.brew-tap-token.outputs.token }}


### PR DESCRIPTION
## Description

This fixes the goreleaser args from upgrading to v2: https://github.com/defenseunicorns/maru-runner/actions/runs/9422452413/job/25960959321

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
