### PR TITLE
feat: allow direct calling of tasks with inputs when required inputs have default values

### DIFF
--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -57,9 +57,9 @@ func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]str
 		return err
 	}
 
-	// can't call a task directly from the CLI if it has inputs
-	if task.Inputs != nil {
-		return fmt.Errorf("task '%s' contains 'inputs' and cannot be called directly by the CLI", taskName)
+	// can't call a task directly from the CLI if it has inputs that are required without a default
+	if err := validateActionableTaskCall(task.Name, task.Inputs, nil); err != nil {
+		return err
 	}
 
 	if err = runner.checkForTaskLoops(task, runner.TasksFile, setVariables); err != nil {

--- a/src/test/e2e/runner_inputs_test.go
+++ b/src/test/e2e/runner_inputs_test.go
@@ -40,6 +40,22 @@ func TestRunnerInputs(t *testing.T) {
 		require.NotContains(t, stdErr, "{{")
 	})
 
+	t.Run("test that direct calling of task with default values for required inputs work", func(t *testing.T) {
+		t.Parallel()
+
+		stdOut, stdErr, err := e2e.Maru("run", "has-default-and-required", "--file", "src/test/tasks/inputs/tasks-with-inputs.yaml")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "Completed \"echo $INPUT_HAS_DEFAULT_AND_REQUIRED; ; \"")
+	})
+
+	t.Run("test that direct calling of task without default values for required inputs fails", func(t *testing.T) {
+		t.Parallel()
+
+		stdOut, stdErr, err := e2e.Maru("run", "no-default-and-required", "--file", "src/test/tasks/inputs/tasks-with-inputs.yaml")
+		require.Error(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "Failed to run action: task no-default-and-required is missing required inputs:")
+	})
+
 	t.Run("test that inputs that aren't required with no default don't error", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Description
allow direct calling of tasks with inputs when required inputs have default values

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
