### PR TITLE
feat: add =md to flag for list commands to allow md output

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -56,7 +56,7 @@ func init() {
 
 	v.SetDefault(V_LOG_LEVEL, "info")
 	v.SetDefault(V_ARCHITECTURE, "")
-	v.SetDefault(V_NO_LOG_FILE, false)
+	v.SetDefault(V_NO_LOG_FILE, true)
 	v.SetDefault(V_TMP_DIR, "")
 
 	rootCmd.PersistentFlags().StringVarP(&logLevelString, "log-level", "l", v.GetString(V_LOG_LEVEL), lang.RootCmdFlagLogLevel)
@@ -87,7 +87,7 @@ func cliSetup() {
 		}
 	}
 
-	if !skipLogFile && !listTasks && !listAllTasks {
+	if !skipLogFile && listTasks == "" && listAllTasks == "" {
 		if err := utils.UseLogFile(); err != nil {
 			message.SLog.Warn(fmt.Sprintf("Unable to setup log file: %s", err.Error()))
 		}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -87,7 +87,7 @@ func cliSetup() {
 		}
 	}
 
-	if !skipLogFile && listTasks == "" && listAllTasks == "" {
+	if !skipLogFile && listTasks == listOff && listAllTasks == listOff {
 		if err := utils.UseLogFile(); err != nil {
 			message.SLog.Warn(fmt.Sprintf("Unable to setup log file: %s", err.Error()))
 		}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -56,7 +56,7 @@ func init() {
 
 	v.SetDefault(V_LOG_LEVEL, "info")
 	v.SetDefault(V_ARCHITECTURE, "")
-	v.SetDefault(V_NO_LOG_FILE, true)
+	v.SetDefault(V_NO_LOG_FILE, false)
 	v.SetDefault(V_TMP_DIR, "")
 
 	rootCmd.PersistentFlags().StringVarP(&logLevelString, "log-level", "l", v.GetString(V_LOG_LEVEL), lang.RootCmdFlagLogLevel)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -31,6 +31,9 @@ var listTasks bool
 // listAllTasks is a flag to print available tasks in a TaskFileLocation
 var listAllTasks bool
 
+// output is a flag to change the output of a task list
+var output string
+
 // setRunnerVariables provides a map of set variables from the command line
 var setRunnerVariables map[string]string
 
@@ -73,8 +76,9 @@ var runCmd = &cobra.Command{
 		}
 
 		if listTasks || listAllTasks {
-			rows := [][]string{
-				{"Name", "Description"},
+			rows := [][]string{}
+			if output != "md" {
+				rows = append(rows, []string{"Name", "Description"})
 			}
 			for _, task := range tasksFile.Tasks {
 				rows = append(rows, []string{task.Name, task.Description})
@@ -88,9 +92,20 @@ var runCmd = &cobra.Command{
 				}
 			}
 
-			err := pterm.DefaultTable.WithHasHeader().WithData(rows).Render()
-			if err != nil {
-				message.Fatalf(err, "Error listing tasks: %s", err.Error())
+			switch output {
+			case "md":
+				fmt.Println("| Name | Description |")
+				fmt.Println("|------|-------------|")
+				for _, row := range rows {
+					if len(row) == 2 {
+						fmt.Printf("| **%s** | %s |\n", row[0], row[1])
+					}
+				}
+			default:
+				err := pterm.DefaultTable.WithHasHeader().WithData(rows).Render()
+				if err != nil {
+					message.Fatalf(err, "Error listing tasks: %s", err.Error())
+				}
 			}
 
 			return
@@ -203,5 +218,6 @@ func init() {
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
 	runFlags.BoolVarP(&listTasks, "list", "t", false, lang.CmdRunList)
 	runFlags.BoolVarP(&listAllTasks, "list-all", "T", false, lang.CmdRunListAll)
+	runFlags.StringVarP(&output, "output", "o", "", lang.CmdRunListAll)
 	runFlags.StringToStringVar(&setRunnerVariables, "set", nil, lang.CmdRunSetVarFlag)
 }

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,16 +24,37 @@ import (
 	goyaml "github.com/goccy/go-yaml"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // listTasks is a flag to print available tasks in a TaskFileLocation (no includes)
-var listTasks bool
+var listTasks listFlag
 
 // listAllTasks is a flag to print available tasks in a TaskFileLocation
-var listAllTasks bool
+var listAllTasks listFlag
 
-// output is a flag to change the output of a task list
-var output string
+// listFlag defines the flag behavior for task list flags
+type listFlag string
+
+const (
+	listOff listFlag = ""
+	listOn  listFlag = "true" // value set by flag package on bool flag
+	listMd  listFlag = "md"
+)
+
+// IsBoolFlag causes a bare list flag to be set as the string 'true'.  This
+// allows the use of a bare list flag or setting a string ala '--list=md'.
+func (i *listFlag) IsBoolFlag() bool { return true }
+func (i *listFlag) String() string   { return string(*i) }
+
+func (i *listFlag) Set(value string) error {
+	v := listFlag(value)
+	if v != listOn && v != listMd {
+		return fmt.Errorf("error: list flags expect '%v' or '%v'", listOn, listMd)
+	}
+	*i = v
+	return nil
+}
 
 // setRunnerVariables provides a map of set variables from the command line
 var setRunnerVariables map[string]string
@@ -75,25 +97,27 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		if listTasks || listAllTasks {
+		listFormat := listTasks
+		if listAllTasks != listOff {
+			listFormat = listAllTasks
+		}
+
+		if listFormat != listOff {
 			rows := [][]string{}
-			if output != "md" {
-				rows = append(rows, []string{"Name", "Description"})
-			}
 			for _, task := range tasksFile.Tasks {
 				rows = append(rows, []string{task.Name, task.Description})
 			}
 
 			// If ListAllTasks, add tasks from included files
-			if listAllTasks {
+			if listAllTasks != listOff {
 				err = listTasksFromIncludes(&rows, tasksFile)
 				if err != nil {
 					message.Fatalf(err, "Cannot list tasks: %s", err.Error())
 				}
 			}
 
-			switch output {
-			case "md":
+			switch listFormat {
+			case listMd:
 				fmt.Println("| Name | Description |")
 				fmt.Println("|------|-------------|")
 				for _, row := range rows {
@@ -102,6 +126,7 @@ var runCmd = &cobra.Command{
 					}
 				}
 			default:
+				rows = append([][]string{{"Name", "Description"}}, rows...)
 				err := pterm.DefaultTable.WithHasHeader().WithData(rows).Render()
 				if err != nil {
 					message.Fatalf(err, "Error listing tasks: %s", err.Error())
@@ -216,8 +241,18 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runFlags := runCmd.Flags()
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
-	runFlags.BoolVarP(&listTasks, "list", "t", false, lang.CmdRunList)
-	runFlags.BoolVarP(&listAllTasks, "list-all", "T", false, lang.CmdRunListAll)
-	runFlags.StringVarP(&output, "output", "o", "", lang.CmdRunListAll)
+
+	// Setup the --list flag
+	flag.Var(&listTasks, "list", lang.CmdRunList)
+	listPFlag := pflag.PFlagFromGoFlag(flag.Lookup("list"))
+	listPFlag.Shorthand = "t"
+	runFlags.AddFlag(listPFlag)
+
+	// Setup the --list-all flag
+	flag.Var(&listAllTasks, "list-all", lang.CmdRunList)
+	listAllPFlag := pflag.PFlagFromGoFlag(flag.Lookup("list-all"))
+	listAllPFlag.Shorthand = "T"
+	runFlags.AddFlag(listAllPFlag)
+
 	runFlags.StringToStringVar(&setRunnerVariables, "set", nil, lang.CmdRunSetVarFlag)
 }

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -209,7 +209,7 @@ func TestTaskRunner(t *testing.T) {
 		require.NotContains(t, stdErr, "default")
 	})
 
-	t.Run("run list tasks", func(t *testing.T) {
+	t.Run("run --list tasks", func(t *testing.T) {
 		t.Parallel()
 		gitRev, err := e2e.GetGitRevision()
 		if err != nil {
@@ -236,6 +236,41 @@ func TestTaskRunner(t *testing.T) {
 
 		stdOut, stdErr, err := e2e.Maru("run", "--list-all", "--set", setVar, "--file", "src/test/tasks/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdOut, "echo-env-var")
+		require.Contains(t, stdOut, "Test that env vars take precedence")
+		require.Contains(t, stdOut, "foo:foobar")
+		require.Contains(t, stdOut, "remote:echo-var")
+	})
+
+	t.Run("run --list=md tasks", func(t *testing.T) {
+		t.Parallel()
+		gitRev, err := e2e.GetGitRevision()
+		if err != nil {
+			return
+		}
+		setVar := fmt.Sprintf("GIT_REVISION=%s", gitRev)
+
+		stdOut, stdErr, err := e2e.Maru("run", "--list=md", setVar, "--file", "src/test/tasks/tasks.yaml")
+
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdOut, "|------|-------------|")
+		require.Contains(t, stdOut, "echo-env-var")
+		require.Contains(t, stdOut, "Test that env vars take precedence")
+		require.Contains(t, stdOut, "remote-import")
+		require.Contains(t, stdOut, "action")
+	})
+
+	t.Run("run --list-all=md tasks", func(t *testing.T) {
+		t.Parallel()
+		gitRev, err := e2e.GetGitRevision()
+		if err != nil {
+			return
+		}
+		setVar := fmt.Sprintf("GIT_REVISION=%s", gitRev)
+
+		stdOut, stdErr, err := e2e.Maru("run", "--list-all=md", "--set", setVar, "--file", "src/test/tasks/tasks.yaml")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdOut, "|------|-------------|")
 		require.Contains(t, stdOut, "echo-env-var")
 		require.Contains(t, stdOut, "Test that env vars take precedence")
 		require.Contains(t, stdOut, "foo:foobar")


### PR DESCRIPTION
## Description

This adds a new flag option on Maru to output md when listing tasks. Usage:

```sh
maru run --list=md
maru run --list-all=md
```

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
