### PR TITLE
feat: add a dry run flag for validating tasks

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -31,6 +31,9 @@ var listTasks bool
 // listAllTasks is a flag to print available tasks in a TaskFileLocation
 var listAllTasks bool
 
+// dryRun is a flag to only load / validate tasks without running commands
+var dryRun bool
+
 // setRunnerVariables provides a map of set variables from the command line
 var setRunnerVariables map[string]string
 
@@ -100,7 +103,7 @@ var runCmd = &cobra.Command{
 		if len(args) > 0 {
 			taskName = args[0]
 		}
-		if err := runner.Run(tasksFile, taskName, setRunnerVariables); err != nil {
+		if err := runner.Run(tasksFile, taskName, setRunnerVariables, dryRun); err != nil {
 			message.Fatalf(err, "Failed to run action: %s", err.Error())
 		}
 	},
@@ -203,5 +206,6 @@ func init() {
 	runFlags.StringVarP(&config.TaskFileLocation, "file", "f", config.TasksYAML, lang.CmdRunFlag)
 	runFlags.BoolVarP(&listTasks, "list", "t", false, lang.CmdRunList)
 	runFlags.BoolVarP(&listAllTasks, "list-all", "T", false, lang.CmdRunListAll)
+	runFlags.BoolVar(&dryRun, "dry-run", false, lang.CmdRunDryRun)
 	runFlags.StringToStringVar(&setRunnerVariables, "set", nil, lang.CmdRunSetVarFlag)
 }

--- a/src/config/lang/english.go
+++ b/src/config/lang/english.go
@@ -51,6 +51,7 @@ const (
 	CmdRunWithVarFlag = "Set the inputs for a task from the command line (KEY=value)"
 	CmdRunList        = "List available tasks in a task file"
 	CmdRunListAll     = "List all available tasks in a task file, including tasks from included files"
+	CmdRunDryRun      = "Validate the task without actually running any commands"
 )
 
 // Common Errors

--- a/src/pkg/runner/actions.go
+++ b/src/pkg/runner/actions.go
@@ -63,11 +63,15 @@ func (r *Runner) performAction(action types.Action, withs map[string]string, inp
 			return err
 		}
 	} else {
-		err := RunAction(action.BaseAction, r.envFilePath, r.variableConfig)
-		if err != nil {
-			return err
+		if r.dryRun {
+			cmdEscaped := helpers.Truncate(action.Cmd, 60, false)
+			message.SLog.Info(cmdEscaped)
+		} else {
+			err := RunAction(action.BaseAction, r.envFilePath, r.variableConfig)
+			if err != nil {
+				return err
+			}
 		}
-
 	}
 	return nil
 }

--- a/src/pkg/runner/actions.go
+++ b/src/pkg/runner/actions.go
@@ -144,10 +144,9 @@ func RunAction[T any](action *types.BaseAction[T], envFilePath string, variableC
 		action.SetVariables = []variables.Variable[T]{}
 	}
 
-	// if this is a dry run, print the command that would run (with vars templated) and return
+	// if this is a dry run, print the command that would run and return
 	if dryRun {
-		processedCmd := utils.TemplateString(variableConfig.GetSetVariables(), cmd)
-		fmt.Println(processedCmd)
+		fmt.Println(cmd)
 		return nil
 	}
 

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -27,10 +27,14 @@ type Runner struct {
 	TaskNameMap    map[string]bool
 	envFilePath    string
 	variableConfig *variables.VariableConfig[variables.ExtraVariableInfo]
+	dryRun         bool
 }
 
 // Run runs a task from tasks file
-func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]string) error {
+func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]string, dryRun bool) error {
+	if dryRun {
+		message.SLog.Info("Dry-run has been set - printing the commands that would run:")
+	}
 
 	// Populate the variables loaded in the root task file
 	rootVariables := tasksFile.Variables
@@ -61,6 +65,7 @@ func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]str
 		TasksFile:      tasksFile,
 		TaskNameMap:    map[string]bool{},
 		variableConfig: combinedVariableConfig,
+		dryRun:         dryRun,
 	}
 
 	task, err := runner.getTask(taskName)

--- a/src/pkg/runner/runner.go
+++ b/src/pkg/runner/runner.go
@@ -33,7 +33,7 @@ type Runner struct {
 // Run runs a task from tasks file
 func Run(tasksFile types.TasksFile, taskName string, setVariables map[string]string, dryRun bool) error {
 	if dryRun {
-		message.SLog.Info("Dry-run has been set - printing the commands that would run:")
+		message.SLog.Info("Dry-run has been set - only printing the commands that would run:")
 	}
 
 	// Populate the variables loaded in the root task file

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -423,7 +423,7 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-conditional-nested-nested-nested-task-comp-var-inputs", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "\"input val2 equals 5 and variable VAL1 equals 5\"")
+		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
 	})
 	t.Run("test calling a task with nested task calling a task with false conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
@@ -436,14 +436,14 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-original-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "\"input val2 equals 5 and variable VAL1 equals 5\"")
+		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
 	})
 
 	t.Run("test calling a task with nested task calling a task with new style var as input true conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-new-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "\"input val2 equals 5 and variable VAL1 equals 5\"")
+		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
 	})
 
 	t.Run("run successful pattern", func(t *testing.T) {

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -461,4 +461,13 @@ func TestTaskRunner(t *testing.T) {
 		require.Error(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "\"HELLO\" does not match pattern \"^HELLO$\"")
 	})
+
+	t.Run("dry run", func(t *testing.T) {
+		t.Parallel()
+
+		stdOut, stdErr, err := e2e.Maru("run", "--dry-run", "--file", "src/test/tasks/tasks.yaml", "env-from-file")
+		require.NoError(t, err, stdOut, stdErr)
+		require.Contains(t, stdErr, "Dry-running \"echo $MARU_ARCH\"")
+		require.Contains(t, stdErr, "echo env var from calling task - $SECRET_KEY")
+	})
 }

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -423,7 +423,7 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-conditional-nested-nested-nested-task-comp-var-inputs", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
+		require.Contains(t, stdErr, "Completed \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 	t.Run("test calling a task with nested task calling a task with false conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
@@ -436,14 +436,14 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-original-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
+		require.Contains(t, stdErr, "Completed \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 
 	t.Run("test calling a task with nested task calling a task with new style var as input true conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-new-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
+		require.Contains(t, stdErr, "Completed \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 
 	t.Run("run successful pattern", func(t *testing.T) {

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -423,7 +423,7 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-conditional-nested-nested-nested-task-comp-var-inputs", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
+		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 	t.Run("test calling a task with nested task calling a task with false conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
@@ -436,14 +436,14 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-original-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
+		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 
 	t.Run("test calling a task with nested task calling a task with new style var as input true conditional comparing variables and inputs", func(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "true-condition-var-as-input-new-syntax-nested-nested-with-comp", "--file", "src/test/tasks/conditionals/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, "input val2 equals 5 and variable VAL1 equals 5")
+		require.Contains(t, stdErr, "Running \"echo \\\"input val2 equals 5 and variable VAL1 equals 5\\\"\"")
 	})
 
 	t.Run("run successful pattern", func(t *testing.T) {

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -468,6 +468,6 @@ func TestTaskRunner(t *testing.T) {
 		stdOut, stdErr, err := e2e.Maru("run", "--dry-run", "--file", "src/test/tasks/tasks.yaml", "env-from-file")
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "Dry-running \"echo $MARU_ARCH\"")
-		require.Contains(t, stdErr, "echo env var from calling task - $SECRET_KEY")
+		require.Contains(t, stdOut, "echo env var from calling task - $SECRET_KEY")
 	})
 }


### PR DESCRIPTION
## Description

This adds a `--dry-run` flag to test a Maru tasks flow without actually running any commands.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
