### PR TITLE
chore!: remove architecture from maru

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -61,7 +61,6 @@ func init() {
 	v.SetDefault(V_TMP_DIR, "")
 
 	rootCmd.PersistentFlags().StringVarP(&logLevelString, "log-level", "l", v.GetString(V_LOG_LEVEL), lang.RootCmdFlagLogLevel)
-	rootCmd.PersistentFlags().StringVarP(&config.CLIArch, "architecture", "a", v.GetString(V_ARCHITECTURE), lang.RootCmdFlagArch)
 	rootCmd.PersistentFlags().BoolVar(&message.NoProgress, "no-progress", v.GetBool(V_NO_PROGRESS), lang.RootCmdFlagNoProgress)
 	rootCmd.PersistentFlags().BoolVar(&skipLogFile, "no-log-file", v.GetBool(V_NO_LOG_FILE), lang.RootCmdFlagSkipLogFile)
 	rootCmd.PersistentFlags().StringVar(&config.TempDirectory, "tmpdir", v.GetString(V_TMP_DIR), lang.RootCmdFlagTempDir)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -4,10 +4,6 @@
 // Package config contains configuration strings for maru
 package config
 
-import (
-	"runtime"
-)
-
 const (
 	// TasksYAML is the string for the default tasks.yaml
 	TasksYAML = "tasks.yaml"
@@ -17,9 +13,6 @@ const (
 )
 
 var (
-	// CLIArch is the computer architecture of the device executing the CLI commands
-	CLIArch string
-
 	// CLIVersion track the version of the CLI
 	CLIVersion = "unset"
 
@@ -39,23 +32,8 @@ var (
 	// MaxStack is the maximum stack size for task references
 	MaxStack = 2048
 
-	extraEnv = map[string]string{"MARU": "true", "MARU_ARCH": GetArch()}
+	extraEnv = map[string]string{"MARU": "true"}
 )
-
-// GetArch returns the arch based on a priority list with options for overriding.
-func GetArch(archs ...string) string {
-	// List of architecture overrides.
-	priority := append([]string{CLIArch}, archs...)
-
-	// Find the first architecture that is specified.
-	for _, arch := range priority {
-		if arch != "" {
-			return arch
-		}
-	}
-
-	return runtime.GOARCH
-}
 
 // AddExtraEnv adds a new envirmentment variable to the extraEnv to make it available to actions
 func AddExtraEnv(key string, value string) {

--- a/src/test/common.go
+++ b/src/test/common.go
@@ -20,7 +20,6 @@ import (
 // MaruE2ETest Struct holding common fields most of the tests will utilize.
 type MaruE2ETest struct {
 	MaruBinPath       string
-	Arch              string
 	ApplianceMode     bool
 	ApplianceModeKeep bool
 	RunClusterTests   bool
@@ -54,17 +53,6 @@ func (e2e *MaruE2ETest) Maru(args ...string) (string, string, error) {
 func (e2e *MaruE2ETest) CleanFiles(files ...string) {
 	for _, file := range files {
 		_ = os.RemoveAll(file)
-	}
-}
-
-// GetMismatchedArch determines what architecture our tests are running on,
-// and returns the opposite architecture.
-func (e2e *MaruE2ETest) GetMismatchedArch() string {
-	switch e2e.Arch {
-	case "arm64":
-		return "amd64"
-	default:
-		return "arm64"
 	}
 }
 

--- a/src/test/e2e/main_test.go
+++ b/src/test/e2e/main_test.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/defenseunicorns/maru-runner/src/config"
 	"github.com/defenseunicorns/maru-runner/src/test"
 )
 
@@ -50,7 +49,6 @@ func doAllTheThings(m *testing.M) (int, error) {
 	var err error
 
 	// Set up constants in the global variable that all the tests are able to access
-	e2e.Arch = config.GetArch()
 	e2e.MaruBinPath = path.Join("build", test.GetCLIName())
 	e2e.ApplianceMode = os.Getenv(applianceModeEnvVar) == "true"
 	e2e.ApplianceModeKeep = os.Getenv(applianceModeKeepEnvVar) == "true"

--- a/src/test/e2e/runner_test.go
+++ b/src/test/e2e/runner_test.go
@@ -310,7 +310,6 @@ func TestTaskRunner(t *testing.T) {
 		t.Parallel()
 		stdOut, stdErr, err := e2e.Maru("run", "env-from-file", "--file", "src/test/tasks/tasks.yaml")
 		require.NoError(t, err, stdOut, stdErr)
-		require.Contains(t, stdErr, e2e.Arch)
 		require.Contains(t, stdErr, "not-a-secret")
 		require.Contains(t, stdErr, "3000")
 		require.Contains(t, stdErr, "$env/**/*var with#special%chars!")


### PR DESCRIPTION
## Description

Removes the architecture concept from Maru - right now this is not used internal to Maru and causes breakage when vendored into apps like UDS CLI.

> [!CAUTION]
> :warning: **BREAKING CHANGE** - this is technically a breaking change for any users of the MARU_ARCH variable - this was not widely publicized in docs and likely made little sense to users so usage is expected to have been minimal (though still technically breaking).

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
