### PR TITLE
fix: if the input name has a dash the `${{ .inputs.input-name }}` syntax doesn't work

### DIFF
--- a/src/test/e2e/runner_inputs_test.go
+++ b/src/test/e2e/runner_inputs_test.go
@@ -158,4 +158,11 @@ func TestRunnerInputs(t *testing.T) {
 		require.NoError(t, err, stdOut, stdErr)
 		require.Contains(t, stdErr, "Input1Tmpl: input1 Input1Env: input1 Input2Tmpl: input2 Input2Env: input2 Input3Tmpl: notthedefault Input3Env: notthedefault Var: baz")
 	})
+
+	t.Run("test that verifies that dashes can be used in input names", func(t *testing.T) {
+		stdOut, stdErr, err := e2e.Maru("run", "with:dashes-in-input-names", "--file", "src/test/tasks/inputs/tasks.yaml", "--with", "required-input-with-dashes=foo")
+		require.NoError(t, err, stdOut, stdErr)
+		//require.Contains(t, stdErr, "foo bar foo bar foo bar foo bar")
+		require.Contains(t, stdErr, "foo bar foo bar foo bar")
+	})
 }

--- a/src/test/tasks/inputs/tasks-with-inputs.yaml
+++ b/src/test/tasks/inputs/tasks-with-inputs.yaml
@@ -77,3 +77,16 @@ tasks:
     actions:
       - cmd: |
           echo "Input1Tmpl: ${{ .inputs.input1 }} Input1Env: $INPUT_INPUT1 Input2Tmpl: ${{ .inputs.input2 }} Input2Env: ${INPUT_INPUT2} Input3Tmpl: ${{ .inputs.input3 }} Input3Env: $INPUT_INPUT3 Var: $FOO"
+
+  - name: dashes-in-input-names
+    description: Test task that puts dashes in input names
+    inputs:
+      required-input-with-dashes:
+        description: A required input with dashes in its name
+        required: true
+      default-input-with-dashes:
+        description: A default input with dashes in its name
+        default: bar
+    actions:
+      - cmd: |
+          echo "$INPUT_REQUIRED_INPUT_WITH_DASHES $INPUT_DEFAULT_INPUT_WITH_DASHES ${INPUT_REQUIRED_INPUT_WITH_DASHES} ${INPUT_DEFAULT_INPUT_WITH_DASHES} ${{ .inputs.required-input-with-dashes }} ${{ .inputs.default-input-with-dashes }} ${{ index .inputs "required-input-with-dashes" }} ${{ index .inputs "default-input-with-dashes" }}"


### PR DESCRIPTION
## Description

...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
