### PR TITLE
fix: renovate.json pterm v0.12.80 ignore

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,11 @@
   ],
   "ignorePaths": [],
   "timezone": "America/New_York",
-  "repositories": [
-    "defenseunicorns/maru-runner"
-  ],
   "rebaseStalePrs": true,
   "schedule": [
     "after 12pm and before 11am every weekday"
   ],
   "dependencyDashboard": true,
-  "platform": "github",
-  "onboarding": false,
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "rebaseWhen": "conflicted",
   "commitBodyTable": true,
@@ -62,7 +57,7 @@
       "matchPackageNames": [
         "github.com/pterm/pterm"
       ],
-      "allowedVersions": "!/-v0.12.80$/"
+      "allowedVersions": "!/v0.12.80$/"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -57,7 +57,7 @@
       "matchPackageNames": [
         "github.com/pterm/pterm"
       ],
-      "allowedVersions": "!/v0.12.80$/"
+      "allowedVersions": "!/v0.12.80/"
     }
   ]
 }


### PR DESCRIPTION
## Description

Removes leading `-` and some other config options that aren't valid.

Syntax copied/mirrored from https://github.com/defenseunicorns/uds-common/blob/main/config/renovate.json5#L329

## Related Issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/maru-runner/blob/main/CONTRIBUTING.md) followed
